### PR TITLE
Adds 2023 Mac mini to Supported Devices

### DIFF
--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -101,7 +101,7 @@ Devices:
 - iPhone 13 Pro (2021)
 - iPhone 13 Pro Max (2021)
 - iPhone SE (3rd gen, 2022)
-- Apple TV 4K (7th gen, 2022)
+- Apple TV 4K (3rd gen, 2022)
 
 ### [M2](https://en.wikipedia.org/wiki/Apple_silicon#Apple_M2)
 

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -43,6 +43,7 @@ Devices:
 
 - iPad Pro 11-inch (2nd gen, 2020)
 - iPad Pro 12.9-inch (4th gen, 2020)
+- Developer Transition Kit (2020)
 
 ### [A13 Bionic](https://en.wikipedia.org/wiki/Apple_A13)
 

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -113,6 +113,7 @@ Devices:
 - MacBook Pro 13" with two Thunderbolt 3 ports (2022)
 - iPad Pro 11-inch (4th gen, 2022)
 - iPad Pro 12.9-inch (6th gen, 2022)
+- Mac mini (2023)
 
 ## Recent devices without a Neural Engine
 


### PR DESCRIPTION
- Adds the 2023 Mac mini to Supported Devices section under M2 chip
- Adds the 2020 Developer Transition Kit for Apple Silicon to Supported Devices section under A12Z Bionic chip
- Fixes the 2022 Apple TV 4K Generation Number (mislabelled as 7th gen)
- Currently holding off on adding MacBook Pros with M2 Pro/Max chips
  - These models seem to have the same Neural Engine as the M2 chips at 15.8 trillion operations per second
  - Not sure how we want to handle M-series chip variants
    - A12 Bionic, A12X Bionic, and A12Z Bionic all have their own section despite sharing the same Neural Engine
    - The 2021 MacBook Pro models with M1 Pro/Max chips haven't been documented yet either
      - See #17 for an example