### PR TITLE
Add M1/M2 Pro, Max, and Ultra, and add iMac 24-inch (2021)

### DIFF
--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -91,13 +91,20 @@ Devices:
 
 The Neural Engine is not available on Intel-based Macs, only on Macs with Apple Silicon.
 
-### [M1 Pro and M1 Max](https://en.wikipedia.org/wiki/Apple_M1#Variants)
-The Neural Engine in M1 Pro and M1 Max has 16 cores and can perform up to 11 trillion operations per second. It is most likely identical to the M1's Neural Engine.
+### [M1 Pro](https://en.wikipedia.org/wiki/Apple_M1#Variants)
+The Neural Engine in M1 M1 Max has 16 cores and can perform up to 11 trillion operations per second. It is most likely identical to the M1's Neural Engine.
 
 Devices:
 
 - MacBook Pro 14-inch (2021)
 - MacBook Pro 16-inch (2021)
+
+
+### [M1 Max](https://en.wikipedia.org/wiki/Apple_M1#Variants)
+The Neural Engine in M1 Max has 16 cores and can perform up to 11 trillion operations per second. It is most likely identical to the M1's Neural Engine.
+
+Devices:
+
 - Mac Studio (2022)
 
 ### [M1 Ultra](https://en.wikipedia.org/wiki/Apple_M1#Variants)
@@ -123,7 +130,7 @@ Devices:
 - iPhone SE (3rd gen, 2022)
 - Apple TV 4K (3rd gen, 2022)
 
-### [M2](https://en.wikipedia.org/wiki/Apple_silicon#Apple_M2)
+### [M2](https://en.wikipedia.org/wiki/Apple_M2)
 
 The M2 appears to use the 16-core Neural Engine from the A15 Bionic, performing up to 15.8 trillion operations per second.
 
@@ -134,6 +141,25 @@ Devices:
 - iPad Pro 11-inch (4th gen, 2022)
 - iPad Pro 12.9-inch (6th gen, 2022)
 - Mac mini (2023)
+
+### [M2 Pro](https://en.wikipedia.org/wiki/Apple_M2#Variants)
+
+The M2 Pro uses the same 16-core Neural Engine from the M2, performing up to 15.8 trillion operations per second.
+
+Devices:
+
+- MacBook Pro 14-inch (2023)
+- MacBook Pro 16-inch (2023)
+- Mac mini (2023)
+
+### [M2 Max](https://en.wikipedia.org/wiki/Apple_M2#Variants)
+
+The M2 Max uses the same 16-core Neural Engine from the M2, performing up to 15.8 trillion operations per second.
+
+Devices:
+
+- MacBook Pro 14-inch (2023)
+- MacBook Pro 16-inch (2023)
 
 ### [A16 Bionic](https://en.wikipedia.org/wiki/Apple_A16)
 

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -99,7 +99,6 @@ Devices:
 - MacBook Pro 14-inch (2021)
 - MacBook Pro 16-inch (2021)
 
-
 ### [M1 Max](https://en.wikipedia.org/wiki/Apple_M1#Variants)
 The Neural Engine in M1 Max has 16 cores and can perform up to 11 trillion operations per second. It is most likely identical to the M1's Neural Engine.
 

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -84,6 +84,7 @@ Devices:
 - MacBook Air (2020)
 - MacBook Pro 13" with two Thunderbolt 3 ports (2020)
 - Mac mini (2020)
+- iMac 24-inch (2021)
 - iPad Pro 11-inch (3rd gen, 2021)
 - iPad Pro 12.9-inch (5th gen, 2021)
 - iPad Air (5th gen, 2022)

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -91,6 +91,22 @@ Devices:
 
 The Neural Engine is not available on Intel-based Macs, only on Macs with Apple Silicon.
 
+### [M1 Pro and M1 Max](https://en.wikipedia.org/wiki/Apple_M1#Variants)
+The Neural Engine in M1 Pro and M1 Max has 16 cores and can perform up to 11 trillion operations per second. It is most likely identical to the M1's Neural Engine.
+
+Devices:
+
+- MacBook Pro 14-inch (2021)
+- MacBook Pro 16-inch (2021)
+- Mac Studio (2022)
+
+### [M1 Ultra](https://en.wikipedia.org/wiki/Apple_M1#Variants)
+The Neural Engine in M1 Ultra has 32 cores and can perform up to 22 trillion operations per second.
+
+Devices:
+
+- Mac Studio (2022)
+
 ### [A15 Bionic](https://en.wikipedia.org/wiki/Apple_A15)
 
 The A15 has a 16-core Neural Engine, with the same amount of cores it can perform 15.8 trillion operations per second (43% faster than the previous generation). 


### PR DESCRIPTION
This pull requests adds M1 and M2 Pro, Max, and Ultra. It also adds iMac 24-inch (2021) which wasn't originally included in the M1 list.